### PR TITLE
Fix Issue in String to Hex Conversion

### DIFF
--- a/src/agb/string/agbstring.py
+++ b/src/agb/string/agbstring.py
@@ -99,7 +99,7 @@ class Agbstring:
         while True:
             sequence, size = self.str_to_hex_map[pattern]
             assert sequence is not None, f'Sequence is None at {pattern}'
-            encoded += sequence
+            encoded += tuple(sequence)
             if pattern == '':
                 break
             if size == 0:


### PR DESCRIPTION
Currently, there is an issue in the `str_to_hex` method caused by type incompatibilities.
The change made in this PR fixes this issue.